### PR TITLE
Ticketmaster api added

### DIFF
--- a/event-finder/backend/api/index.py
+++ b/event-finder/backend/api/index.py
@@ -1,11 +1,19 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
+from .ticketmaster import TicketmasterService
 
 app = FastAPI()
 
-@app.get("/")
-def read_root():
-    return {"Hello": "World", "Platform": "Vercel"}
+tm_service = TicketmasterService()
 
-@app.get("/items/{item_id}")
-def read_item(item_id: int, q: str = None):
-    return {"item_id": item_id, "q": q}
+@app.get("/api/events")
+async def get_events(location: str, date: str):
+    try:
+        events = await tm_service.search_events(city=location, date_str=date)
+        
+        if not events:
+            return {"message": "No events found for this location/date", "data": []}
+            
+        return {"data": events}
+
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))

--- a/event-finder/backend/api/ticketmaster.py
+++ b/event-finder/backend/api/ticketmaster.py
@@ -1,0 +1,54 @@
+import os
+import httpx
+
+from dotenv import load_dotenv
+  # This finds the .env file and loads it
+
+class TicketmasterService:
+    BASE_URL = "https://app.ticketmaster.com/discovery/v2/events.json"
+
+    def __init__(self):
+        load_dotenv()
+        self.api_key = os.environ.get("TICKETMASTER_API_KEY")
+        if not self.api_key:
+            raise ValueError("TICKETMASTER_API_KEY is not set in environment variables")
+
+    async def search_events(self, city: str, date_str: str):
+        formatted_date = f"{date_str}T00:00:00Z"
+
+        params = {
+            "apikey": self.api_key,
+            "city": city,
+            "startDateTime": formatted_date,
+            "sort": "date,asc",
+            "size": 10
+        }
+
+        async with httpx.AsyncClient() as client:
+            try:
+                response = await client.get(self.BASE_URL, params=params)
+                response.raise_for_status()
+                data = response.json()
+                
+                return self._parse_events(data)
+                
+            except httpx.HTTPError as e:
+                print(f"Ticketmaster API Error: {e}")
+                raise e
+
+    def _parse_events(self, data):
+        clean_events = []
+        
+        if "_embedded" in data and "events" in data["_embedded"]:
+            for event in data["_embedded"]["events"]:
+                venue_info = event.get("_embedded", {}).get("venues", [{}])[0]
+                
+                clean_events.append({
+                    "name": event.get("name"),
+                    "url": event.get("url"),
+                    "date": event.get("dates", {}).get("start", {}).get("localDate"),
+                    "venue": venue_info.get("name", "TBA"),
+                    "city": venue_info.get("city", {}).get("name", "Unknown")
+                })
+                
+        return clean_events


### PR DESCRIPTION
Added ticketmaster api, and have it as the default return when queried. Please ask for the api key if you don't have it yet - it is currently posted in our team discord.

API Query:
https://pj13-event-finder-backend.vercel.app/api/events?location={location}&date={YYYY-MM-DD}

Example:
https://pj13-event-finder-backend.vercel.app/api/events?location=London&date=2026-05-27