### PR TITLE
Simple fix to show allevents vs ticketmaster distinction on frontend

### DIFF
--- a/event-finder/backend/api/allevents.py
+++ b/event-finder/backend/api/allevents.py
@@ -25,7 +25,7 @@ def process_event(item: Dict, default_loc: str) -> Dict:
         "price": extract_price(item),
         "description": item.get("description", ""),
         "type": item.get("@type", ""),
-        "source": "allevents.in"
+        "source": "All Events"
     }
 
 def fetch_events(

--- a/event-finder/backend/api/index.py
+++ b/event-finder/backend/api/index.py
@@ -135,7 +135,7 @@ def search_events(
     for event in tm_data.get("events", []):
         key = get_event_key(event.get("name"), event.get("date"))
         if key not in seen_event_keys:
-            event["source"] = "ticketmaster"
+            event["source"] = "Ticketmaster"
             combined_events.append(event)
             seen_event_keys.add(key)
             tm_count += 1

--- a/event-finder/frontend/src/components/resultsPanel.js
+++ b/event-finder/frontend/src/components/resultsPanel.js
@@ -137,7 +137,7 @@ export default function ResultsPanel({ events, loading, error }) {
                           rel="noopener noreferrer"
                           className="inline-block mt-4 text-purple-600 no-underline font-semibold transition-colors hover:text-purple-800 hover:underline"
                         >
-                          View on Ticketmaster →
+                          View on {event.source} →
                         </a>
                       )}
                     </div>


### PR DESCRIPTION
Fixed fontend to show wether the event was found on ticketmaster or all events. The web links always reflect this and take the user to the correct site.